### PR TITLE
Fix CSS property in Jupyter notebook

### DIFF
--- a/plant-id-system.ipynb
+++ b/plant-id-system.ipynb
@@ -690,7 +690,7 @@
         "        .gradio-container {\n",
         "            background: linear-gradient(135deg, #1e293b 0%, #6495ED 100%);\n",
         "            font-family: 'Segoe UI', 'Roboto', sans-serif;\n",
-        "            font-color: #10b981;\n",
+        "            color: #10b981;\n",
         "            font-size: 16px;\n",
         "            min-height: 100vh;\n",
         "        }\n",


### PR DESCRIPTION
## Summary
- fix incorrect `font-color` CSS property in `plant-id-system.ipynb`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684094dd0d00832092c6db9d8bf40b0c