### PR TITLE
Fix analyze button hover style

### DIFF
--- a/plant-id-system.ipynb
+++ b/plant-id-system.ipynb
@@ -785,7 +785,7 @@
         "        }\n",
         "\n",
         "        .analyze-button:hover {\n",
-        "            background: linear-gradient(135deg, #1e293b 0%, #334155 100%)) !important;\n",
+        "            background: linear-gradient(135deg, #1e293b 0%, #334155 100%) !important;\n",
         "            transform: translateY(-2px) !important;\n",
         "        }\n",
         "        \"\"\"\n",


### PR DESCRIPTION
## Summary
- correct stray parenthesis in the `.analyze-button:hover` CSS rule

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684094da0b8083209f9e45d4dc074613