### PR TITLE
Fix CSS syntax

### DIFF
--- a/plant-id-system.ipynb
+++ b/plant-id-system.ipynb
@@ -785,7 +785,7 @@
         "        }\n",
         "\n",
         "        .analyze-button:hover {\n",
-        "            background: linear-gradient(135deg, #1e293b 0%, #334155 100%)) !important;\n",
+        "            background: linear-gradient(135deg, #1e293b 0%, #334155 100%) !important;\n",
         "            transform: translateY(-2px) !important;\n",
         "        }\n",
         "        \"\"\"\n",


### PR DESCRIPTION
## Summary
- fix gradient syntax for hover style in the notebook

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684093858288832093169a708fe14035